### PR TITLE
Fix R7 and examples args

### DIFF
--- a/notebooks/economic-test/economic-test.py
+++ b/notebooks/economic-test/economic-test.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     group = []
     
     if not args.all and not args.single_test and not args.groups and not args.no_external:
-        print('Keyword to define the test scope is required, e.g. --all, --single test E1_test, --groups election, --no_external.')
+        print('Keyword to define the test scope is required, e.g. --all, --single_test E1_test, --groups election, --no_external.')
         exit(1)
         
     if args.all:

--- a/notebooks/economic-test/test_case.py
+++ b/notebooks/economic-test/test_case.py
@@ -752,10 +752,11 @@ def R7_test(single):
     logger.info(f"current and last block numbers: {block}, {last_block}")
     while last_block - block > 32:
         block = getBlockNumber()
-    if block == last_block:
-        logger.info(f"current at the last block, wait until the 6th block in the new epoch")
+    if block == last_block or block + 1 == last_block:
+        logger.info(f"current at the last block (or last block - 1), wait until the 5th/6th block in the new epoch")
         while block < last_block+6:
             block = getBlockNumber()
+            time.sleep (5)
     logger.info(f"current block {block}, will begin collecting infos...")
 
     acc_rewards_prev = dict()


### PR DESCRIPTION
had issue with R7 test whenever current block was the second last block, see here twice :

```
=============== Starting R7_test ===============

INFO:economic-test:Test-R7: Sum of validator and delegator earning should match the block reward
INFO:economic-test:current and last block numbers: 7332, 7333
INFO:economic-test:current block 7332, will begin collecting infos...
INFO:economic-test:new block 7333 reached, will begin testing...
INFO:economic-test:new block 7334 reached, will begin testing...
Traceback (most recent call last):
  File "economic-test.py", line 89, in <module>
    curr_test = run_test(curr_test)
  File "economic-test.py", line 13, in run_test
    res, curr_test = curr_test(single)
  File "E:\Projects\harmony-log-analysis\notebooks\economic-test\test_case.py", line 813, in R7_test
    dels_prev = delegations_prev[address]
KeyError: 'one10jvjrtwpz2sux2ngktg3kq7m3sdz5p5au5l8c8'

```

and
```
=============== Starting R7_test ===============

INFO:economic-test:Test-R7: Sum of validator and delegator earning should match the block reward
INFO:economic-test:current and last block numbers: 7522, 7523
INFO:economic-test:current block 7522, will begin collecting infos...
INFO:economic-test:new block 7523 reached, will begin testing...
WARNING:economic-test:Test-R7: Fail
WARNING:economic-test:for validator one1egemh5e9xjy3x8d3cq0kq7mw4sw4jjwgkc7axs, expected block reward, 4.79655702367579008000e+17, validator block reward, 5.08884913245211520000e+17, delegation reward, 5.08884913245211584000e+17

INFO:economic-test:new block 7524 reached, will begin testing...
Traceback (most recent call last):
  File "economic-test.py", line 64, in <module>
    run_test(getattr(test_case, args.single_test))
  File "economic-test.py", line 13, in run_test
    res, curr_test = curr_test(single)
  File "E:\Projects\harmony-log-analysis\notebooks\economic-test\test_case.py", line 813, in R7_test
    dels_prev = delegations_prev[address]
KeyError: 'one1j0wd4ndjaxdfqxqmd4upq3sk0cvkaymsfrl56x'
```

so decided to fix it : 
```
=============== Starting R7_test ===============

INFO:economic-test:Test-R7: Sum of validator and delegator earning should match the block reward
INFO:economic-test:current and last block numbers: 7979, 7979
INFO:economic-test:current at the last block (or last block - 1), wait until the 5th/6th block in the new epoch
INFO:economic-test:current block 7985, will begin collecting infos...
INFO:economic-test:new block 7986 reached, will begin testing...
INFO:economic-test:new block 7987 reached, will begin testing...
INFO:economic-test:Test-R7: Succeed
```
